### PR TITLE
Allow multiple violations for the same field in WithFieldViolations

### DIFF
--- a/gobusx/bus.go
+++ b/gobusx/bus.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Config struct {
-	Database gormx.DatabaseConfig `confx:",squash"`
+	Database gormx.DatabaseConfig `confx:"database"`
 }
 
 var SetupBus = []any{

--- a/gormx/database.go
+++ b/gormx/database.go
@@ -117,7 +117,10 @@ func Open(ctx context.Context, conf *DatabaseConfig, opts ...gorm.Option) (*gorm
 				// We don't want to use any foreign key constraint.
 				DisableForeignKeyConstraintWhenMigrating: true,
 				CreateBatchSize:                          100,
-				PrepareStmt:                              true,
+				// PrepareStmt is disabled because pgx driver already enables prepared statement cache
+				// by default (extended protocol). Enabling this would create redundant statement caching
+				// at both GORM and driver levels, potentially causing memory overhead without performance gain.
+				PrepareStmt: false,
 				// Enable GORM error translation to convert database-specific errors into standardized GORM errors.
 				// Benefits:
 				// 1. Cross-database compatibility: Unified error handling across different databases

--- a/gormx/database.go
+++ b/gormx/database.go
@@ -25,6 +25,8 @@ import (
 	_ "embed"
 )
 
+var DefaultCreateBatchSize = 100
+
 type AuthMethod string
 
 const (
@@ -116,20 +118,18 @@ func Open(ctx context.Context, conf *DatabaseConfig, opts ...gorm.Option) (*gorm
 			&gorm.Config{
 				// We don't want to use any foreign key constraint.
 				DisableForeignKeyConstraintWhenMigrating: true,
-				CreateBatchSize:                          100,
+				// CreateBatchSize is set to DefaultCreateBatchSize to improve performance by reducing the number of round trips to the database.
+				CreateBatchSize: DefaultCreateBatchSize,
 				// PrepareStmt is disabled because pgx driver already enables prepared statement cache
 				// by default (extended protocol). Enabling this would create redundant statement caching
 				// at both GORM and driver levels, potentially causing memory overhead without performance gain.
 				PrepareStmt: false,
 				// Enable GORM error translation to convert database-specific errors into standardized GORM errors.
 				// Benefits:
-				// 1. Cross-database compatibility: Unified error handling across different databases
-				//    - MySQL: "Error 1062: Duplicate entry 'xxx' for key 'xxx'" -> gorm.ErrDuplicatedKey
-				//    - PostgreSQL: "ERROR: duplicate key value violates unique constraint" -> gorm.ErrDuplicatedKey
-				// 2. Better error handling: Enables type-based error handling (errors.Is(err, gorm.ErrDuplicatedKey))
-				//    instead of fragile string matching
-				// 3. Clean abstraction: Business logic remains database-agnostic, making it easier to switch
-				//    database providers or run multiple databases in production
+				// 1. Better error handling: Enables type-based error handling (errors.Is(err, gorm.ErrDuplicatedKey))
+				//    instead of fragile string matching against raw database error messages.
+				//    Example: PostgreSQL "ERROR: duplicate key value violates unique constraint" -> gorm.ErrDuplicatedKey
+				// 2. Clean abstraction: Business logic remains database-agnostic
 				TranslateError: true,
 				// QueryFields:                              true,
 			},

--- a/gormx/embed/default-database-config.yaml
+++ b/gormx/embed/default-database-config.yaml
@@ -4,6 +4,7 @@ database:
   tracing:
     excludeQuery: false
     excludeQueryVars: false
+    maxQueryLength: 0 # Maximum query length for tracing, 0 uses default (4096)
   maxIdleConns: 20
   maxOpenConns: 200
   connMaxLifetime: "30m"

--- a/slogx/slog.go
+++ b/slogx/slog.go
@@ -4,8 +4,17 @@ import (
 	"log/slog"
 )
 
+type Level string
+
+const (
+	LevelDebug Level = "debug"
+	LevelInfo  Level = "info"
+	LevelWarn  Level = "warn"
+	LevelError Level = "error"
+)
+
 type Config struct {
-	Level string `confx:"level" usage:"Logging level" validate:"required,oneof=debug info warn error"`
+	Level Level `confx:"level" usage:"Logging level" validate:"required,oneof=debug info warn error"`
 }
 
 func SetupDefaultLogger(conf *Config) (*slog.Logger, error) {

--- a/statusx/field.go
+++ b/statusx/field.go
@@ -13,7 +13,14 @@ import (
 
 // BadRequest creates a new Status with the InvalidArgument code and a flattened list of field violations.
 func BadRequest(inputs ...any) *Status {
-	return New(codes.InvalidArgument, statusv1.ErrorReason_INVALID_ARGUMENT.String(), "invalid argument").WithFlattenFieldViolations(inputs...)
+	violations, err := FlattenFieldViolations(inputs...)
+	if err != nil {
+		panic(err)
+	}
+	if len(violations) == 0 {
+		return New(codes.OK, statusv1.ErrorReason_OK.String(), "ok")
+	}
+	return New(codes.InvalidArgument, statusv1.ErrorReason_INVALID_ARGUMENT.String(), "invalid argument").WithFieldViolations(violations...)
 }
 
 // FormatField formats a dotted field path by applying a formatting function to each segment

--- a/statusx/validate_test.go
+++ b/statusx/validate_test.go
@@ -85,6 +85,7 @@ func TestValidate(t *testing.T) {
 		err := Validate(context.Background(), validator)
 		violations := ToFieldViolations(err, "")
 
+		assert.NoError(t, err)
 		assert.Empty(t, violations)
 	})
 
@@ -94,7 +95,24 @@ func TestValidate(t *testing.T) {
 		err := Validate(context.Background(), validator)
 		violations := ToFieldViolations(err, "")
 
+		assert.NoError(t, err)
 		assert.Empty(t, violations)
+	})
+
+	t.Run("mockContextValidator with empty violations returns nil error", func(t *testing.T) {
+		validator := &mockContextValidator{violations: []*FieldViolation{}}
+
+		err := Validate(context.Background(), validator)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("mockSimpleValidator with empty violations returns nil error", func(t *testing.T) {
+		validator := &mockSimpleValidator{violations: []*FieldViolation{}}
+
+		err := Validate(context.Background(), validator)
+
+		assert.NoError(t, err)
 	})
 
 	t.Run("returns empty for non-validator input", func(t *testing.T) {

--- a/statusx/vproto.go
+++ b/statusx/vproto.go
@@ -100,6 +100,7 @@ func WriteVProtoHTTPError(err error, w http.ResponseWriter, r *http.Request) (xe
 
 	verr := &vproto.ValidationError{
 		Code:           cmp.Or(errorInfo.GetReason(), code.String()),
+		Msg:            st.Message(),
 		DefaultViewMsg: cmp.Or(localizedMessage.GetMessage(), st.Message()),
 	}
 
@@ -110,6 +111,7 @@ func WriteVProtoHTTPError(err error, w http.ResponseWriter, r *http.Request) (xe
 			verr.FieldViolations = append(verr.FieldViolations, &vproto.ValidationError_FieldViolation{
 				Field:          fv.GetField(),
 				Code:           fv.GetReason(),
+				Msg:            fv.GetDescription(),
 				DefaultViewMsg: cmp.Or(fv.GetLocalizedMessage().GetMessage(), fv.GetDescription()),
 			})
 		}


### PR DESCRIPTION
- Simplify WithFieldViolations to append all violations without deduplication
- Remove duplicate field checking and replacement logic
- Update method documentation to reflect append-only behavior
- Refactor tests to validate new append strategy
- Add test cases for violations with zero errors in Validate function