### PR TITLE
gormx: Add HardDeleteModel with BeforeCreate hook for UUID generation

### DIFF
--- a/gormx/model.go
+++ b/gormx/model.go
@@ -22,3 +22,16 @@ func (m *Model) BeforeCreate(_ *gorm.DB) error {
 	}
 	return nil
 }
+
+type HardDeleteModel struct {
+	ID        string    `gorm:"size:36;primaryKey" json:"id"`
+	CreatedAt time.Time `gorm:"not null" json:"createdAt"`
+	UpdatedAt time.Time `gorm:"not null" json:"updatedAt"`
+}
+
+func (m *HardDeleteModel) BeforeCreate(_ *gorm.DB) error {
+	if m.ID == "" {
+		m.ID = uuid.NewString()
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `HardDeleteModel` (no soft delete) with `BeforeCreate` hook to auto-assign UUIDs.
> 
> - **Models (`gormx/model.go`)**:
>   - **New `HardDeleteModel`**: Base model without `DeletedAt` (hard deletes) containing `ID`, `CreatedAt`, `UpdatedAt`.
>   - **Hook**: `BeforeCreate` sets `ID` to a new UUID when empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3541ac9ea0d8c461cee782600e68137e78f39d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->