### PR TITLE
tracing reason

### DIFF
--- a/statusx/connect.go
+++ b/statusx/connect.go
@@ -19,6 +19,9 @@ func UnaryConnectInterceptor(ib *i18nx.I18N, shouldConvert func(ctx context.Cont
 			ctx = i18nx.NewContext(ctx, ib)
 			lang := ib.LanguageFromContext(ctx)
 			res, err := next(ctx, req)
+			if err != nil {
+				TracingReason(ctx, err)
+			}
 			err = TranslateError(err, ib, lang)
 			if err != nil {
 				convert := true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds tracing of error reason to spans in Connect and gRPC interceptors via a new TracingReason helper.
> 
> - **Interceptors**
>   - `statusx/UnaryConnectInterceptor`: on error, call `TracingReason(ctx, err)` before translating.
>   - `statusx/UnaryServerInterceptor`: on error, call `TracingReason(ctx, err)` before translating.
> - **Helper**
>   - Add `TracingReason(ctx, err)` to extract `statusx.Status` reason and append it to the tracing span using `appkit/logtracing`.
> - **Deps**
>   - Import `github.com/theplant/appkit/logtracing` in `statusx/grpc.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 066dff73e2f4014d68e12b502666caab0957a20e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->