### PR TITLE
gormx: Add WithoutTracing for gorm tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __*
 !__tests__
 vite.config.ts.timestamp-*.mjs
 .cursor
+.windsurf

--- a/gormx/model.go
+++ b/gormx/model.go
@@ -10,7 +10,7 @@ import (
 var TimePrecision = time.Microsecond
 
 type Model struct {
-	ID        string         `gorm:"size:36;primaryKey" json:"id"`
+	ID        string         `gorm:"primaryKey" json:"id"`
 	CreatedAt time.Time      `gorm:"not null" json:"createdAt"`
 	UpdatedAt time.Time      `gorm:"not null" json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"deletedAt"`
@@ -24,7 +24,7 @@ func (m *Model) BeforeCreate(_ *gorm.DB) error {
 }
 
 type HardDeleteModel struct {
-	ID        string    `gorm:"size:36;primaryKey" json:"id"`
+	ID        string    `gorm:"primaryKey" json:"id"`
 	CreatedAt time.Time `gorm:"not null" json:"createdAt"`
 	UpdatedAt time.Time `gorm:"not null" json:"updatedAt"`
 }

--- a/gormx/tracing_test.go
+++ b/gormx/tracing_test.go
@@ -1,0 +1,55 @@
+package gormx_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	gklog "github.com/go-kit/log"
+	"github.com/qor5/x/v3/gormx"
+	"github.com/stretchr/testify/require"
+	kitlog "github.com/theplant/appkit/log"
+	"github.com/theplant/appkit/logtracing"
+)
+
+type TracingTestModel struct {
+	ID   uint `gorm:"primaryKey"`
+	Name string
+}
+
+func TestWithoutTracing(t *testing.T) {
+	ctx := context.Background()
+	db := suite.DB()
+
+	err := suite.ResetDB(ctx, &TracingTestModel{})
+	require.NoError(t, err)
+
+	err = db.WithContext(ctx).Create(&TracingTestModel{Name: "test"}).Error
+	require.NoError(t, err)
+
+	// Create a custom logger to track tracing log calls
+	var logCount atomic.Int32
+	countingLogger := kitlog.Logger{Logger: gklog.LoggerFunc(func(keyvals ...any) error {
+		logCount.Add(1)
+		return nil
+	})}
+
+	// Set custom logger in context
+	tracedCtx, _ := logtracing.StartSpan(ctx, "test-parent")
+	tracedCtx = kitlog.Context(tracedCtx, countingLogger)
+	defer logtracing.EndSpan(tracedCtx, nil)
+
+	// Normal query: should produce tracing log
+	logCount.Store(0)
+	var result1 TracingTestModel
+	err = db.WithContext(tracedCtx).First(&result1).Error
+	require.NoError(t, err)
+	require.Greater(t, logCount.Load(), int32(0), "normal query should trigger tracing log")
+
+	// WithoutTracing: should NOT produce tracing log
+	logCount.Store(0)
+	var result2 TracingTestModel
+	err = db.WithContext(tracedCtx).Scopes(gormx.WithoutTracing()).First(&result2).Error
+	require.NoError(t, err)
+	require.Equal(t, int32(0), logCount.Load(), "WithoutTracing should not trigger tracing log")
+}


### PR DESCRIPTION
…disable functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `WithoutTracing` scope to disable GORM query tracing and removes the `size:36` constraint from model ID fields.
> 
> - **gormx/models**:
>   - Remove `size:36` constraint from `Model.ID` and `HardDeleteModel.ID` (still `primaryKey`).
> - **gormx/tracing**:
>   - Add `WithoutTracing()` scope and `keyTracingDisabled` to disable tracing per-query.
>   - Guard `before`/`after` hooks to skip span creation/logging when disabled.
> - **Tests**:
>   - Add `gormx/tracing_test.go` verifying tracing is skipped when `WithoutTracing` is applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57779e52122b78d391d9f054ab3924a32afd8da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->