### PR TITLE
Content-Disposition set

### DIFF
--- a/oss/s3/s3.go
+++ b/oss/s3/s3.go
@@ -266,8 +266,9 @@ func (client Client) GetURL(ctx context.Context, path string) (url string, err e
 	if client.Config.S3Endpoint == "" {
 		if client.Config.ACL == "private" || client.Config.ACL == "authenticated-read" {
 			presignReq, err := s3.NewPresignClient(client.S3).PresignGetObject(ctx, &s3.GetObjectInput{
-				Bucket: aws.String(client.Config.Bucket),
-				Key:    aws.String(client.ToS3Key(path)),
+				Bucket:                     aws.String(client.Config.Bucket),
+				Key:                        aws.String(client.ToS3Key(path)),
+				ResponseContentDisposition: aws.String(fmt.Sprintf(`attachment; filename="%s"`, filepath.Base(path))),
 			}, func(po *s3.PresignOptions) {
 				po.Expires = 1 * time.Hour
 			})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets `ResponseContentDisposition` when generating S3 presigned URLs for private/authenticated objects, forcing downloads with the original filename.
> 
> - Update `GetURL` to include `Content-Disposition: attachment; filename="<name>"` via `PresignGetObject` options
> - No other logic paths changed; only presign behavior for private/authenticated-read ACLs is affected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3276b495de2ee20c3046187d797027f1569f5782. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->