### PR TITLE
fix(ci): use pnpm install --frozen-lockfile

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dep
         working-directory: ui/vuetifyx/vuetifyxjs
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: build doc
         working-directory: ui/vuetifyx/vuetifyxjs

--- a/.github/workflows/vuetifyjs-build.yml
+++ b/.github/workflows/vuetifyjs-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build project
         run: |
           cd ui/vuetifyx/vuetifyxjs
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm run build
 
       - name: Commit build artifacts

--- a/.github/workflows/vuetifyjs-test.yml
+++ b/.github/workflows/vuetifyjs-test.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9.15.5
       - name: Build and Test
-        run: cd ./ui/vuetifyx/vuetifyxjs/ && pnpm install && pnpm run build && pnpm run test:unit
+        run: cd ./ui/vuetifyx/vuetifyxjs/ && pnpm install --frozen-lockfile && pnpm run build && pnpm run test:unit


### PR DESCRIPTION
## Summary

- CI workflows (`vuetifyjs-build.yml`, `vuetifyjs-test.yml`, `doc-build.yml`) now use `pnpm install --frozen-lockfile` instead of bare `pnpm install`
- Prevents silent dependency version upgrades in CI, mitigating supply-chain attack risk (ref: axios 1.14.1 / 0.30.4 incident)

## Test plan

- [ ] CI pipeline runs successfully with `--frozen-lockfile`
- [ ] Verify no lockfile mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)