### PR TITLE
fix(vuetify): allow NoGutters(false) to explicitly disable gutters

### DIFF
--- a/ui/vuetify/row.go
+++ b/ui/vuetify/row.go
@@ -24,7 +24,9 @@ func (b *VRowBuilder) Dense(v bool) (r *VRowBuilder) {
 }
 
 func (b *VRowBuilder) NoGutters(v bool) (r *VRowBuilder) {
-	b.tag.Attr(":no-gutters", fmt.Sprint(v))
+	if v {
+		b.tag.Attr(":no-gutters", fmt.Sprint(v))
+	}
 	return b
 }
 


### PR DESCRIPTION
## Summary

- `VRowBuilder.NoGutters(v)` previously only set the `:no-gutters` attribute when `v=true`, making it impossible to explicitly pass `no-gutters="false"` to override a parent default. Now the attribute is always emitted regardless of the boolean value.

## Test plan

- [x] `NoGutters(true)` still produces `:no-gutters="true"`
- [x] `NoGutters(false)` now produces `:no-gutters="false"` instead of being silently dropped