### PR TITLE
feat(goquex): record goque.job.latency_ms on perform spans

### DIFF
--- a/goquex/tracing.go
+++ b/goquex/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/qor5/go-que"
@@ -81,6 +82,9 @@ func PerformWithTracing(notifier errornotifier.Notifier) func(next func(ctx cont
 				"span.role":        "consumer",
 				"goque.job.id":     j.ID(),
 				"goque.queue.name": j.Plan().Queue,
+				// How long past its scheduled RunAt the job waited before a
+				// worker picked it up; rises when the queue is backlogged.
+				"goque.job.latency_ms": time.Since(j.Plan().RunAt).Milliseconds(),
 			}
 
 			payload, err := jsonx.Marshal(j.Plan())


### PR DESCRIPTION
## Summary

Consumer (perform) spans emitted by `goquex.PerformWithTracing` carry no signal for how long a job waited in the queue before a worker picked it up, so queue backlog is invisible in tracing backends — a job that waited 10 minutes and ran in 2 seconds looks identical to one that started instantly.

This adds one span KV on every perform span:

- `goque.job.latency_ms` = `time.Since(j.Plan().RunAt).Milliseconds()` — how long past its scheduled `RunAt` the job started executing.

Since the KV lives in `spanKVs`, it is also included in the errornotifier context on job failure/panic, same as the existing keys.

kakuyasu-services already emits the equivalent app-level KV (`queue.job_latency_ms` in its `queutil.GetQuePerformKVs`) and alerts on it in Honeycomb; adding it to goquex gives every goquex consumer (e.g. mad) the same queue-backlog observability without per-project instrumentation.

## Test plan

- `go build ./goquex/`, `go vet ./goquex/`, `gofmt -l goquex/` all clean.
- Behavior change is a single additive KV; no existing keys or control flow touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)