### PR TITLE
feat(gormx): raise DefaultCreateBatchSize from 100 to 512

### DIFF
--- a/gormx/database.go
+++ b/gormx/database.go
@@ -28,7 +28,7 @@ import (
 	_ "embed"
 )
 
-var DefaultCreateBatchSize = 100
+var DefaultCreateBatchSize = 512
 
 type AuthMethod string
 


### PR DESCRIPTION
## What

Raise `gormx.DefaultCreateBatchSize` from 100 to 512 to reduce round trips on batch inserts. It stays a package-level var, so callers can still override it in code before opening the DB.

## Verification

- `go build ./...` passes
- `go test ./...` in `gormx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)